### PR TITLE
Added reconfigure flow to change charger host/port

### DIFF
--- a/custom_components/ev_metron_websockets/config_flow.py
+++ b/custom_components/ev_metron_websockets/config_flow.py
@@ -11,6 +11,7 @@ from homeassistant.const import CONF_PORT, CONF_HOST, CONF_FRIENDLY_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 
 from .const import DOMAIN
 from .hub import MetronEVHub
@@ -25,6 +26,16 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_PORT, default="80"): str,
     }
 )
+
+
+def _reconfigure_schema(host: str, port: str) -> vol.Schema:
+    """Schema for editing the connection details of an existing entry."""
+    return vol.Schema(
+        {
+            vol.Required(CONF_HOST, default=host): str,
+            vol.Required(CONF_PORT, default=port): str,
+        }
+    )
 
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
@@ -73,6 +84,69 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
         )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle changing the host/port of an already configured charger.
+
+        The friendly name is kept unchanged because every entity's unique_id is
+        derived from it; only the connection details are editable here so the
+        existing entities, automations and dashboards are preserved.
+        """
+        entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            new_data = {**entry.data, **user_input}
+            try:
+                await validate_input(self.hass, new_data)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "cannot_connect"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                self._migrate_device_identifier(
+                    entry, entry.data[CONF_HOST], new_data[CONF_HOST]
+                )
+                return self.async_update_reload_and_abort(
+                    entry, data=new_data, reason="reconfigure_successful"
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=_reconfigure_schema(
+                entry.data[CONF_HOST], entry.data[CONF_PORT]
+            ),
+            errors=errors,
+        )
+
+    def _migrate_device_identifier(
+        self, entry: config_entries.ConfigEntry, old_host: str, new_host: str
+    ) -> None:
+        """Move the device registry entry to the new host-based identifier.
+
+        The device is identified by ``(DOMAIN, host.lower())``; without this the
+        old device would be orphaned and a new one created, losing its area and
+        name customisations.
+        """
+        if old_host.lower() == new_host.lower():
+            return
+
+        device_reg = dr.async_get(self.hass)
+        device = device_reg.async_get_device(
+            identifiers={(DOMAIN, old_host.lower())}
+        )
+        if device is not None:
+            device_reg.async_update_device(
+                device.id,
+                new_identifiers={(DOMAIN, new_host.lower())},
+            )
 
 
 class CannotConnect(HomeAssistantError):

--- a/custom_components/ev_metron_websockets/strings.json
+++ b/custom_components/ev_metron_websockets/strings.json
@@ -7,6 +7,14 @@
           "friendly_name": "[%key:common::config_flow::data::friendly_name%]",
           "port": "[%key:common::config_flow::data::port%]"
         }
+      },
+      "reconfigure": {
+        "title": "Change charger host/port",
+        "description": "Update the hostname or IP address of your charger. Existing entities, automations and dashboards are preserved.",
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]"
+        }
       }
     },
     "error": {
@@ -15,7 +23,8 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   }
 }

--- a/custom_components/ev_metron_websockets/translations/en.json
+++ b/custom_components/ev_metron_websockets/translations/en.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Device is already configured",
+            "reconfigure_successful": "Re-configuration was successful"
         },
         "error": {
             "cannot_connect": "Failed to connect",
@@ -15,6 +16,14 @@
                     "friendly_name": "Friendly name",
                     "port": "Port",
                     "api_token": "API token"
+                }
+            },
+            "reconfigure": {
+                "title": "Change charger host/port",
+                "description": "Update the hostname or IP address of your charger. Existing entities, automations and dashboards are preserved.",
+                "data": {
+                    "host": "Host",
+                    "port": "Port"
                 }
             }
         }


### PR DESCRIPTION
The charger hostname or IP address can now be updated on an existing
config entry via the Reconfigure menu, without deleting and re-adding the
device. Existing entities, automations and dashboards are preserved, and
the device registry entry is migrated to the new host-based identifier so
its area and name customisations are kept.
