### PR TITLE
Fix sensor state_class exposure (#65) and raise integration code quality

### DIFF
--- a/custom_components/ev_metron_websockets/__init__.py
+++ b/custom_components/ev_metron_websockets/__init__.py
@@ -11,12 +11,24 @@ from homeassistant.const import (
 )
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import issue_registry as ir
 
 from .const import DOMAIN
 from .hub import MetronEVHub
 
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BUTTON, Platform.NUMBER, Platform.SELECT]
+PLATFORMS: list[Platform] = [
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+    Platform.BUTTON,
+    Platform.NUMBER,
+    Platform.SELECT,
+]
+
+# unique_id suffixes for entities moved from sensor.* to binary_sensor.* (#65)
+_MOVED_TO_BINARY_SENSOR = ["car_connected", "charging"]
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Metron EV from a config entry."""
@@ -28,12 +40,50 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.data[CONF_PORT],
     )
 
+    _async_migrate_car_status_entities(hass, entry, hub)
+
     entry.async_create_background_task(hass, hub.update(), "ev_metron_update")
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = hub
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
+
+
+def _async_migrate_car_status_entities(hass: HomeAssistant, entry: ConfigEntry, hub: MetronEVHub) -> None:
+    """Remove the old sensor.* car_connected/charging entities superseded by binary_sensor.*.
+
+    They were booleans wrongly exposed as SensorEntity with a BinarySensorDeviceClass
+    (#65). Domain is part of the registry key, so HA won't rename them on its own -
+    left alone they'd sit as permanently-unavailable orphans once the sensor.py
+    classes are removed. Raises a repair issue so the user knows to update any
+    automations/dashboards pointing at the old entity_ids.
+    """
+    registry = er.async_get(hass)
+    moved = []
+    for suffix in _MOVED_TO_BINARY_SENSOR:
+        unique_id = f"{hub.name}_{suffix}"
+        old_entity_id = registry.async_get_entity_id(Platform.SENSOR, DOMAIN, unique_id)
+        if old_entity_id is None:
+            continue
+        registry.async_remove(old_entity_id)
+        new_entity_id = f"binary_sensor.{old_entity_id.split('.', 1)[1]}"
+        moved.append((old_entity_id, new_entity_id))
+
+    if not moved:
+        return
+
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        f"car_status_entities_moved_{entry.entry_id}",
+        is_fixable=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="car_status_entities_moved",
+        translation_placeholders={
+            "changes": ", ".join(f"{old} -> {new}" for old, new in moved)
+        },
+    )
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""

--- a/custom_components/ev_metron_websockets/binary_sensor.py
+++ b/custom_components/ev_metron_websockets/binary_sensor.py
@@ -1,0 +1,100 @@
+"""Binary sensors for Metron EV vehicle connection/charging state."""
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .entity import MetronEVBaseEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Add binary sensors for setup hub object."""
+    hub = hass.data[DOMAIN][config_entry.entry_id]
+
+    async_add_entities(
+        [
+            CarConnected(hub),
+            CarCharging(hub),
+            WifiToNetworkEnabled(hub),
+            WifiToNetworkConnected(hub),
+        ]
+    )
+
+
+class CarConnected(MetronEVBaseEntity, BinarySensorEntity):
+    """Whether a vehicle is plugged into the charger."""
+
+    def __init__(self, hub) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(hub)
+        self._attr_unique_id = f"{hub.name}_car_connected"
+        self._attr_name = f"{hub.name} car connected"
+        self._attr_device_class = BinarySensorDeviceClass.PLUG
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if a vehicle is connected."""
+        return int(self._hub.metron_ev_status) in [2, 3, 4, 7]
+
+
+class CarCharging(MetronEVBaseEntity, BinarySensorEntity):
+    """Whether the vehicle is actively charging."""
+
+    def __init__(self, hub) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(hub)
+        self._attr_unique_id = f"{hub.name}_charging"
+        self._attr_name = f"{hub.name} charging"
+        self._attr_device_class = BinarySensorDeviceClass.BATTERY_CHARGING
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if actively charging."""
+        return int(self._hub.metron_ev_status) == 3 and int(self._hub.TCA0_cmp2) != 8000
+
+
+class WifiToNetworkEnabled(MetronEVBaseEntity, BinarySensorEntity):
+    """Whether WiFi-to-network is enabled. Diagnostic, disabled by default."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, hub) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(hub)
+        self._attr_unique_id = f"{hub.name}_wifi_to_network_enable"
+        self._attr_name = f"{hub.name} WiFi to network enabled"
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if WiFi-to-network is enabled."""
+        return bool(self._hub.wifi_to_network_enable)
+
+
+class WifiToNetworkConnected(MetronEVBaseEntity, BinarySensorEntity):
+    """Whether WiFi-to-network is currently connected. Diagnostic, disabled by default."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, hub) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(hub)
+        self._attr_unique_id = f"{hub.name}_wifi_to_network_state"
+        self._attr_name = f"{hub.name} WiFi to network connected"
+        self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if WiFi-to-network is currently connected."""
+        return bool(self._hub.wifi_to_network_state)

--- a/custom_components/ev_metron_websockets/button.py
+++ b/custom_components/ev_metron_websockets/button.py
@@ -90,7 +90,7 @@ class MetronButton(MetronEVBaseEntity, ButtonEntity):
     ) -> None:
         """Initialize the button."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_{description.key}"
+        self._attr_unique_id = f"{hub.name}_{description.key}"
         self.entity_description = description
 
     async def async_press(self) -> None:

--- a/custom_components/ev_metron_websockets/config_flow.py
+++ b/custom_components/ev_metron_websockets/config_flow.py
@@ -52,7 +52,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     )
 
     if not await metron_ev_hub.test_endpoint():
-        raise InvalidAuth
+        raise CannotConnect
 
     # Return info that you want to store in the config entry.
     return {"title": data[CONF_FRIENDLY_NAME]}
@@ -73,8 +73,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 info = await validate_input(self.hass, user_input)
             except CannotConnect:
                 errors["base"] = "cannot_connect"
-            except InvalidAuth:
-                errors["base"] = "invalid_auth"
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
@@ -104,8 +102,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 await validate_input(self.hass, new_data)
             except CannotConnect:
-                errors["base"] = "cannot_connect"
-            except InvalidAuth:
                 errors["base"] = "cannot_connect"
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception")
@@ -151,7 +147,3 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 class CannotConnect(HomeAssistantError):
     """Error to indicate we cannot connect."""
-
-
-class InvalidAuth(HomeAssistantError):
-    """Error to indicate there is invalid auth."""

--- a/custom_components/ev_metron_websockets/entity.py
+++ b/custom_components/ev_metron_websockets/entity.py
@@ -19,9 +19,9 @@ class MetronEVBaseEntity(Entity):
     def device_info(self) -> DeviceInfo:
         """Return information to link this entity with the correct device."""
         return DeviceInfo(
-            identifiers={(DOMAIN, self._hub._id)},
-            model=f"{self._hub._name} charger at {self._hub._host}",
-            name=f"{self._hub._name} Charger",
+            identifiers={(DOMAIN, self._hub.id)},
+            model=f"{self._hub.name} charger at {self._hub.host}",
+            name=f"{self._hub.name} Charger",
             manufacturer="Metron EV",
         )
 

--- a/custom_components/ev_metron_websockets/hub.py
+++ b/custom_components/ev_metron_websockets/hub.py
@@ -59,14 +59,37 @@ class MetronEVHub:
         self._HC12_Signal_Present = 0
         self._TCA0_cmp2 = 0
         self._message_format = "unknown"
+        self._metron_charge_control_version = None
+        self._temperature_sens_read = None
+        self._solar_phases = 0
+        self._house_phases = 0
+        self._car_phases = 0
+        self._wifi_to_network_enable = 0
+        self._wifi_to_network_state = 0
+        self._since_last_reset_energy = 0
+        self._id_station = None
+        self._number_of_stations = 0
+        self._charging_cable_max_current = 0
+        self._vreg1_set_charging_current = 0
+        self._vreg2_set_charging_current = 0
+        self._station_max_charging_current = 0
+        self._front_button = None
+        self._dynamic_enable = 0
+        self._p_grid_limit = None
+        self._grid_system = None
+        self._kwh_limit_slider = None
 
     async def test_endpoint(self) -> bool:
-        """Test if we can subscribe to the websocket."""
-        success = False
-        async with websockets.connect(self._uri) as websocket:
-            if websocket.state is State.OPEN:
-              success = True
-        return success
+        """Test if we can subscribe to the websocket.
+
+        Returns False (rather than raising) on any connection failure so the
+        config flow can show "cannot connect" instead of an unhandled exception.
+        """
+        try:
+            async with websockets.connect(self._uri) as websocket:
+                return websocket.state is State.OPEN
+        except (OSError, websockets.WebSocketException, TimeoutError):
+            return False
 
     async def update(self) -> None:
         """Background task to loop websocket updates."""
@@ -104,6 +127,25 @@ class MetronEVHub:
                         self._ESP32_timer_delay = latest_message.get("ESP32_timer_delay")
                         self._HC12_Signal_Present = latest_message.get("HC12_Signal_Present")
                         self._TCA0_cmp2 = latest_message.get("TCA0_cmp2")
+                        self._metron_charge_control_version = latest_message.get("Metron_Charge_Control_Version")
+                        self._temperature_sens_read = latest_message.get("temperature_sens_read")
+                        self._solar_phases = latest_message.get("Solar_phases")
+                        self._house_phases = latest_message.get("House_phases")
+                        self._car_phases = latest_message.get("Car_phases")
+                        self._wifi_to_network_enable = latest_message.get("WiFi_to_network_enable")
+                        self._wifi_to_network_state = latest_message.get("WiFi_to_network_state")
+                        self._since_last_reset_energy = latest_message.get("Since_last_reset_energy")
+                        self._id_station = latest_message.get("ID_station")
+                        self._number_of_stations = latest_message.get("number_of_stations")
+                        self._charging_cable_max_current = latest_message.get("Charging_cable_max_current")
+                        self._vreg1_set_charging_current = latest_message.get("Vreg1_set_charging_current")
+                        self._vreg2_set_charging_current = latest_message.get("Vreg2_set_charging_current")
+                        self._station_max_charging_current = latest_message.get("Station_max_charging_current")
+                        self._front_button = latest_message.get("Front_button")
+                        self._dynamic_enable = latest_message.get("Dynamic_Enable")
+                        self._p_grid_limit = latest_message.get("P_grid_limit")
+                        self._grid_system = latest_message.get("Grid_system")
+                        self._kwh_limit_slider = latest_message.get("kWh_limit_slider")
                         await self.publish_updates()
                 # Clean close: server ended the stream normally
                 _LOGGER.debug("WebSocket closed cleanly, reconnecting in 5 s")
@@ -117,9 +159,19 @@ class MetronEVHub:
                 await asyncio.sleep(5)
 
     @property
-    def metron_ev_name(self) -> str:
-        """Return status of station."""
+    def name(self) -> str:
+        """Return the configured friendly name."""
         return self._name
+
+    @property
+    def host(self) -> str:
+        """Return the configured host."""
+        return self._host
+
+    @property
+    def id(self) -> str:
+        """Return the device identifier (lowercased host)."""
+        return self._id
 
     @property
     def TCA0_cmp2(self) -> str:
@@ -277,14 +329,117 @@ class MetronEVHub:
         self._callbacks.discard(callback)
 
     async def publish_updates(self) -> None:
-        """Call all callbacks on update."""
+        """Call all callbacks on update.
+
+        A single entity failing to compute its state (e.g. a malformed message
+        leaving one field un-coercible) must not stop the other entities from
+        updating, or tear down the websocket connection the update loop runs in.
+        """
         for callback in self._callbacks:
-            callback()
+            try:
+                callback()
+            except Exception:
+                _LOGGER.exception("Error notifying entity of update")
 
     @property
     def message_format(self) -> str:
         """Return the last detected websocket message format."""
         return self._message_format
+
+    @property
+    def metron_charge_control_version(self):
+        """Return the firmware version string. None on legacy (pre-JSON) firmware."""
+        return self._metron_charge_control_version
+
+    @property
+    def temperature_sens_read(self):
+        """Return the raw internal temperature sensor reading. Scale/unit not confirmed."""
+        return self._temperature_sens_read
+
+    @property
+    def solar_phases(self):
+        """Return the configured number of solar phases."""
+        return self._solar_phases
+
+    @property
+    def house_phases(self):
+        """Return the configured number of house phases."""
+        return self._house_phases
+
+    @property
+    def car_phases(self):
+        """Return the configured number of car phases."""
+        return self._car_phases
+
+    @property
+    def wifi_to_network_enable(self):
+        """Return whether WiFi-to-network is enabled."""
+        return self._wifi_to_network_enable
+
+    @property
+    def wifi_to_network_state(self):
+        """Return whether WiFi-to-network is currently connected."""
+        return self._wifi_to_network_state
+
+    @property
+    def since_last_reset_energy(self):
+        """Return the energy counter since its last reset."""
+        return self._since_last_reset_energy
+
+    @property
+    def id_station(self):
+        """Return the station identifier. None on legacy (pre-JSON) firmware."""
+        return self._id_station
+
+    @property
+    def number_of_stations(self):
+        """Return the number of stations reported by the charger."""
+        return self._number_of_stations
+
+    @property
+    def charging_cable_max_current(self):
+        """Return the charging cable's maximum current rating, in amps."""
+        return self._charging_cable_max_current
+
+    @property
+    def vreg1_set_charging_current(self):
+        """Return the Vreg1 set charging current, in amps."""
+        return self._vreg1_set_charging_current
+
+    @property
+    def vreg2_set_charging_current(self):
+        """Return the Vreg2 set charging current, in amps."""
+        return self._vreg2_set_charging_current
+
+    @property
+    def station_max_charging_current(self):
+        """Return the station's maximum charging current, in amps."""
+        return self._station_max_charging_current
+
+    @property
+    def front_button(self):
+        """Return the front button state. None on legacy (pre-JSON) firmware."""
+        return self._front_button
+
+    @property
+    def dynamic_enable(self):
+        """Return the dynamic charging enable flag (not a plain boolean; meaning unconfirmed)."""
+        return self._dynamic_enable
+
+    @property
+    def p_grid_limit(self):
+        """Return the grid power limit setting. None on legacy (pre-JSON) firmware."""
+        return self._p_grid_limit
+
+    @property
+    def grid_system(self):
+        """Return the grid system code. None on legacy (pre-JSON) firmware."""
+        return self._grid_system
+
+    @property
+    def kwh_limit_slider(self):
+        """Return the kWh limit slider setting. None on legacy (pre-JSON) firmware."""
+        return self._kwh_limit_slider
 
     @property
     def available(self) -> bool:

--- a/custom_components/ev_metron_websockets/manifest.json
+++ b/custom_components/ev_metron_websockets/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "websockets"
   ],
-  "version": "0.4.0"
+  "version": "0.6.0"
 }

--- a/custom_components/ev_metron_websockets/metron.py
+++ b/custom_components/ev_metron_websockets/metron.py
@@ -6,6 +6,10 @@ import re
 
 _LOGGER = logging.getLogger(__name__)
 
+# Legacy fields that hold text rather than a number; default to "" when missing,
+# every other field defaults to 0 (mirrors assign_variables_json's _n()/_s()).
+_LEGACY_STRING_FIELDS = {"Local_network_IP_string"}
+
 
 def parse_string(input_string):
     """Break up the legacy alphabet-delimited string."""
@@ -20,7 +24,13 @@ def parse_string(input_string):
 
 
 def assign_variables(values):
-    """Assign values to named variables (legacy string format)."""
+    """Assign values to named variables (legacy string format).
+
+    Fields beyond the end of ``values`` default to 0 (or "" for text fields)
+    rather than being left out of the dict, matching assign_variables_json's
+    handling of missing keys — a truncated message from older/newer firmware
+    must not leave callers doing int(None) on a hub attribute.
+    """
     var_names = [
         'Status', 'L1_current_station', 'L2_current_station', 'L3_current_station',
         'L1_current_building', 'L2_current_building', 'L3_current_building',
@@ -36,7 +46,6 @@ def assign_variables(values):
         'Local_network_IP_string', 'ESP32_timer_delay', 'HC12_enable', 'number_of_stations',
         'HC12_Channel', 'HC12_Signal_Present',
     ]
-    parsed_variables = dict(zip(var_names, values))
     n = len(values)
     expected = len(var_names)
     if n != expected:
@@ -44,6 +53,13 @@ def assign_variables(values):
             "Legacy message has %d fields, expected %d — firmware version mismatch?",
             n, expected,
         )
+
+    parsed_variables = {}
+    for index, name in enumerate(var_names):
+        if index < n:
+            parsed_variables[name] = values[index]
+        else:
+            parsed_variables[name] = "" if name in _LEGACY_STRING_FIELDS else 0
     return parsed_variables
 
 
@@ -77,7 +93,7 @@ def assign_variables_json(obj):
         "Dynamic_charging_current_limit": _n('o'),
         "Solar_charging_enable": _n('p'),
         "RFID_enable": _n('q'),
-        "Pwmregister_ESP32_reply_Amps": _n('r'),
+        "PWMRegister_ESP32_reply_Amps": _n('r'),
         "Solar_charging_enable_ESP32_reply": _n('s'),
         "TCA0_cmp2": _n('t'),
         "Dynamic_Enable": _n('u'),
@@ -88,7 +104,7 @@ def assign_variables_json(obj):
         "Previous_charge_energy": _n('E'),
         "Since_last_reset_energy": _n('F'),
         "Lifetime_energy": _n('G'),
-        "Pwmregister_ESP32_slider_Amps": _n('H'),
+        "PWMRegister_ESP32_slider_Amps": _n('H'),
         "WiFi_to_network_enable": _n('I'),
         "Total_house_power": _n('J'),
         "House_energy": _n('K'),
@@ -102,7 +118,7 @@ def assign_variables_json(obj):
         "Local_network_IP_string": _s('S'),
         "ESP32_timer_delay": _n('T'),
         "HC12_enable": _n('U'),
-        "Stevilo_postaj": _n('V'),
+        "number_of_stations": _n('V'),
         "HC12_Channel": _n('W'),
         "HC12_Signal_Present": _n('X'),
         "ID_station": _s('Y'),
@@ -118,7 +134,7 @@ def assign_variables_json(obj):
         "Front_button": _n('AI'),
         "Metron_Charge_Control_Version": _s('AJ'),
         "OCPP_module_code_version": _s('AK'),
-        "temprature_sens_read": _n('AL'),
+        "temperature_sens_read": _n('AL'),
         "RFID_energy": _n('AM'),
         "MCU_booting_code": _n('AN'),
         "temperature_sens_read_OCPP": _n('AO'),
@@ -134,7 +150,7 @@ def assign_variables_json(obj):
         "MCU_booting_code_ISO": _n('AZ'),
         "ISO_EVCCID_AutoCharge_prefix_OCPP": _s('BA'),
         "ISO_AutoCharge_enable": _n('BB'),
-        "kWh_limit_sider": _n('BC'),
+        "kWh_limit_slider": _n('BC'),
         "P_grid_limit": _n('BD'),
         "Grid_system": _n('BE'),
     }

--- a/custom_components/ev_metron_websockets/number.py
+++ b/custom_components/ev_metron_websockets/number.py
@@ -35,8 +35,8 @@ class ChargeDelayTimer(MetronEVBaseEntity, NumberEntity):
     def __init__(self, hub: MetronEVHub) -> None:
         """Initialize the number entity."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_set_charge_delay"
-        self._attr_name = f"{hub._name} charge delay"
+        self._attr_unique_id = f"{hub.name}_set_charge_delay"
+        self._attr_name = f"{hub.name} charge delay"
         self._attr_native_min_value = 0
         self._attr_native_max_value = 720
         self._attr_native_step = 5

--- a/custom_components/ev_metron_websockets/select.py
+++ b/custom_components/ev_metron_websockets/select.py
@@ -33,8 +33,8 @@ class DynamicCurrentLimit(MetronEVBaseEntity, SelectEntity):
     def __init__(self, hub: MetronEVHub) -> None:
         """Initialize the select entity."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_set_current_limit"
-        self._attr_name = f"{hub._name} current limit"
+        self._attr_unique_id = f"{hub.name}_set_current_limit"
+        self._attr_name = f"{hub.name} current limit"
         self._attr_options = CURRENT_OPTIONS
         self._attr_icon = "mdi:current-ac"
 

--- a/custom_components/ev_metron_websockets/sensor.py
+++ b/custom_components/ev_metron_websockets/sensor.py
@@ -5,13 +5,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.const import EntityCategory, UnitOfElectricCurrent, UnitOfEnergy, UnitOfPower, UnitOfTime
 from homeassistant.components.sensor import (
+    SensorEntity,
     SensorStateClass,
     SensorDeviceClass,
 )
-from homeassistant.components.binary_sensor import (
-    BinarySensorDeviceClass,
-)
-
 from .const import DOMAIN
 from .entity import MetronEVBaseEntity
 
@@ -54,39 +51,54 @@ async def async_setup_entry(
             LocalNetworkIPString(hub),
             TimerDelay(hub),
             SignalPresent(hub),
-            CarConnected(hub),
-            CarCharging(hub),
             MessageFormat(hub),
+            FirmwareVersion(hub),
+            InternalTemperature(hub),
+            SolarPhases(hub),
+            HousePhases(hub),
+            CarPhases(hub),
+            SinceLastResetEnergy(hub),
+            StationId(hub),
+            NumberOfStations(hub),
+            ChargingCableMaxCurrent(hub),
+            Vreg1SetChargingCurrent(hub),
+            Vreg2SetChargingCurrent(hub),
+            StationMaxChargingCurrent(hub),
+            FrontButtonState(hub),
+            DynamicChargingEnableFlag(hub),
+            GridPowerLimit(hub),
+            GridSystem(hub),
+            KwhLimitSlider(hub),
         ]
     )
 
-class MetronStatus(MetronEVBaseEntity):
+class MetronStatus(MetronEVBaseEntity, SensorEntity):
     """Metron station status entity."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_station_status"
-        self._attr_name = f"{hub._name} station status"
+        self._attr_unique_id = f"{hub.name}_station_status"
+        self._attr_name = f"{hub.name} station status"
 
     @property
     def state(self) -> str:
         """Return the state of the sensor."""
-        if int(self._hub.metron_ev_status) == 1 and int(self._hub._ESP32_timer_delay) == 0:
+        if int(self._hub.metron_ev_status) == 1 and int(self._hub.ESP32_timer_delay) == 0:
             return "Ready to charge"
-        elif int(self._hub.metron_ev_status) == 1 and int(self._hub._ESP32_timer_delay) != 0:
+        elif int(self._hub.metron_ev_status) == 1 and int(self._hub.ESP32_timer_delay) != 0:
             return "Charging start delayed"
-        elif int(self._hub.metron_ev_status) == 2 and int(self._hub._TCA0_cmp2) != 8000:
+        elif int(self._hub.metron_ev_status) == 2 and int(self._hub.TCA0_cmp2) != 8000:
             return "FULLY CHARGED or charging postponed"
-        elif int(self._hub.metron_ev_status) == 2 and int(self._hub._TCA0_cmp2) == 8000 and int(self._hub._ESP32_timer_delay) == 0:
+        elif int(self._hub.metron_ev_status) == 2 and int(self._hub.TCA0_cmp2) == 8000 and int(self._hub.ESP32_timer_delay) == 0:
             return "Charging stopped"
-        elif int(self._hub.metron_ev_status) == 2 and int(self._hub._TCA0_cmp2) == 8000 and int(self._hub._ESP32_timer_delay) != 0:
+        elif int(self._hub.metron_ev_status) == 2 and int(self._hub.TCA0_cmp2) == 8000 and int(self._hub.ESP32_timer_delay) != 0:
             return "Charging stopped"
-        elif int(self._hub.metron_ev_status) == 3 and int(self._hub._TCA0_cmp2) != 8000:
+        elif int(self._hub.metron_ev_status) == 3 and int(self._hub.TCA0_cmp2) != 8000:
             return "CHARGING"
-        elif int(self._hub.metron_ev_status) == 3 and int(self._hub._TCA0_cmp2) == 8000 and int(self._hub._ESP32_timer_delay) == 0:
+        elif int(self._hub.metron_ev_status) == 3 and int(self._hub.TCA0_cmp2) == 8000 and int(self._hub.ESP32_timer_delay) == 0:
             return "Charging stopped"
-        elif int(self._hub.metron_ev_status) == 3 and int(self._hub._TCA0_cmp2) == 8000 and int(self._hub._ESP32_timer_delay) != 0:
+        elif int(self._hub.metron_ev_status) == 3 and int(self._hub.TCA0_cmp2) == 8000 and int(self._hub.ESP32_timer_delay) != 0:
             return "Charging start delayed"
         elif int(self._hub.metron_ev_status) == 4:
             return "Room ventilation required by the vehicle, charging stopped"
@@ -99,14 +111,14 @@ class MetronStatus(MetronEVBaseEntity):
         else:
             return "Station or vehicle error"
 
-class MetronActive(MetronEVBaseEntity):
+class MetronActive(MetronEVBaseEntity, SensorEntity):
     """Metron station status entity."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_station_active"
-        self._attr_name = f"{hub._name} station active"
+        self._attr_unique_id = f"{hub.name}_station_active"
+        self._attr_name = f"{hub.name} station active"
 
     @property
     def state(self) -> str:
@@ -116,31 +128,31 @@ class MetronActive(MetronEVBaseEntity):
         else:
             return "Disconnected"
 
-class MetronName(MetronEVBaseEntity):
+class MetronName(MetronEVBaseEntity, SensorEntity):
     """Metron station status entity."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_station_name"
-        self._attr_name = f"{hub._name} station name"
+        self._attr_unique_id = f"{hub.name}_station_name"
+        self._attr_name = f"{hub.name} station name"
 
     @property
     def state(self) -> str:
         """Return the state of the sensor."""
 
-        return self._hub.metron_ev_name
+        return self._hub.name
 
-class L1CurrentStation(MetronEVBaseEntity):
+class L1CurrentStation(MetronEVBaseEntity, SensorEntity):
     """Metron station phase 1 current."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_L1_current_station"
-        self._attr_name = f"{hub._name} L1 current"
+        self._attr_unique_id = f"{hub.name}_L1_current_station"
+        self._attr_name = f"{hub.name} L1 current"
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+        self._attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
         self._attr_device_class = SensorDeviceClass.CURRENT
 
     @property
@@ -149,16 +161,16 @@ class L1CurrentStation(MetronEVBaseEntity):
 
         return self._hub.L1_current_station
 
-class L2CurrentStation(MetronEVBaseEntity):
+class L2CurrentStation(MetronEVBaseEntity, SensorEntity):
     """Metron station phase 2 current."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_L2_current_station"
-        self._attr_name = f"{hub._name} L2 current"
+        self._attr_unique_id = f"{hub.name}_L2_current_station"
+        self._attr_name = f"{hub.name} L2 current"
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+        self._attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
         self._attr_device_class = SensorDeviceClass.CURRENT
 
     @property
@@ -167,16 +179,16 @@ class L2CurrentStation(MetronEVBaseEntity):
 
         return self._hub.L2_current_station
 
-class L3CurrentStation(MetronEVBaseEntity):
+class L3CurrentStation(MetronEVBaseEntity, SensorEntity):
     """Metron station phase 3 current."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_L3_current_station"
-        self._attr_name = f"{hub._name} L3 current"
+        self._attr_unique_id = f"{hub.name}_L3_current_station"
+        self._attr_name = f"{hub.name} L3 current"
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+        self._attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
         self._attr_device_class = SensorDeviceClass.CURRENT
 
     @property
@@ -185,16 +197,16 @@ class L3CurrentStation(MetronEVBaseEntity):
 
         return self._hub.L3_current_station
 
-class L1CurrentBuilding(MetronEVBaseEntity):
+class L1CurrentBuilding(MetronEVBaseEntity, SensorEntity):
     """Metron station building phase 1 current."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_L1_current_building"
-        self._attr_name = f"{hub._name} L1 building current"
+        self._attr_unique_id = f"{hub.name}_L1_current_building"
+        self._attr_name = f"{hub.name} L1 building current"
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+        self._attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
         self._attr_device_class = SensorDeviceClass.CURRENT
 
     @property
@@ -203,16 +215,16 @@ class L1CurrentBuilding(MetronEVBaseEntity):
 
         return self._hub.L1_current_building
 
-class L2CurrentBuilding(MetronEVBaseEntity):
+class L2CurrentBuilding(MetronEVBaseEntity, SensorEntity):
     """Metron station building phase 2 current."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_L2_current_building"
-        self._attr_name = f"{hub._name} L2 building current"
+        self._attr_unique_id = f"{hub.name}_L2_current_building"
+        self._attr_name = f"{hub.name} L2 building current"
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+        self._attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
         self._attr_device_class = SensorDeviceClass.CURRENT
 
     @property
@@ -221,16 +233,16 @@ class L2CurrentBuilding(MetronEVBaseEntity):
 
         return self._hub.L2_current_building
 
-class L3CurrentBuilding(MetronEVBaseEntity):
+class L3CurrentBuilding(MetronEVBaseEntity, SensorEntity):
     """Metron station building phase 3 current."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_L3_current_building"
-        self._attr_name = f"{hub._name} L3 building current"
+        self._attr_unique_id = f"{hub.name}_L3_current_building"
+        self._attr_name = f"{hub.name} L3 building current"
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+        self._attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
         self._attr_device_class = SensorDeviceClass.CURRENT
 
     @property
@@ -239,16 +251,16 @@ class L3CurrentBuilding(MetronEVBaseEntity):
 
         return self._hub.L3_current_building
 
-class HouseEnergy(MetronEVBaseEntity):
+class HouseEnergy(MetronEVBaseEntity, SensorEntity):
     """Metron station building phase 3 current."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_house_energy"
-        self._attr_name = f"{hub._name} house energy"
+        self._attr_unique_id = f"{hub.name}_house_energy"
+        self._attr_name = f"{hub.name} house energy"
         self._attr_state_class = SensorStateClass.TOTAL
-        self._attr_unit_of_measurement = UnitOfEnergy.WATT_HOUR
+        self._attr_native_unit_of_measurement = UnitOfEnergy.WATT_HOUR
         self._attr_device_class = SensorDeviceClass.ENERGY
 
     @property
@@ -257,16 +269,16 @@ class HouseEnergy(MetronEVBaseEntity):
 
         return self._hub.House_energy
 
-class L1CurrentSolar(MetronEVBaseEntity):
+class L1CurrentSolar(MetronEVBaseEntity, SensorEntity):
     """Metron solar current."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_solar_current"
-        self._attr_name = f"{hub._name} solar current"
+        self._attr_unique_id = f"{hub.name}_solar_current"
+        self._attr_name = f"{hub.name} solar current"
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+        self._attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
         self._attr_device_class = SensorDeviceClass.CURRENT
 
     @property
@@ -275,16 +287,16 @@ class L1CurrentSolar(MetronEVBaseEntity):
 
         return self._hub.L1_current_solar
 
-class ButtonSetChargingCurrent(MetronEVBaseEntity):
+class ButtonSetChargingCurrent(MetronEVBaseEntity, SensorEntity):
     """Metron station status entity."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_button_set_current"
-        self._attr_name = f"{hub._name} button set current"
+        self._attr_unique_id = f"{hub.name}_button_set_current"
+        self._attr_name = f"{hub.name} button set current"
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+        self._attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
         self._attr_device_class = SensorDeviceClass.CURRENT
 
     @property
@@ -293,16 +305,16 @@ class ButtonSetChargingCurrent(MetronEVBaseEntity):
 
         return self._hub.button_set_charging_current
 
-class MainFuseRating(MetronEVBaseEntity):
+class MainFuseRating(MetronEVBaseEntity, SensorEntity):
     """Metron station status entity."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_main_fuse"
-        self._attr_name = f"{hub._name} main fuse rating"
+        self._attr_unique_id = f"{hub.name}_main_fuse"
+        self._attr_name = f"{hub.name} main fuse rating"
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+        self._attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
         self._attr_device_class = SensorDeviceClass.CURRENT
 
     @property
@@ -311,16 +323,16 @@ class MainFuseRating(MetronEVBaseEntity):
 
         return self._hub.main_fuse_rating
 
-class DynamicChargingCurrentLimit(MetronEVBaseEntity):
+class DynamicChargingCurrentLimit(MetronEVBaseEntity, SensorEntity):
     """Metron station status entity."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_dynamic_charging_current_limit"
-        self._attr_name = f"{hub._name} dynamic charging current limit"
+        self._attr_unique_id = f"{hub.name}_dynamic_charging_current_limit"
+        self._attr_name = f"{hub.name} dynamic charging current limit"
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+        self._attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
         self._attr_device_class = SensorDeviceClass.CURRENT
 
     @property
@@ -329,14 +341,14 @@ class DynamicChargingCurrentLimit(MetronEVBaseEntity):
 
         return self._hub.dynamic_charging_current_limit
 
-class SolarChargingEnable(MetronEVBaseEntity):
+class SolarChargingEnable(MetronEVBaseEntity, SensorEntity):
     """Metron station status entity."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_solar_charging_enable"
-        self._attr_name = f"{hub._name} solar charging enable"
+        self._attr_unique_id = f"{hub.name}_solar_charging_enable"
+        self._attr_name = f"{hub.name} solar charging enable"
 
     @property
     def state(self) -> str:
@@ -348,14 +360,14 @@ class SolarChargingEnable(MetronEVBaseEntity):
         else:
             return "Solar charging activated by switch"
 
-class SolarChargingEnableShort(MetronEVBaseEntity):
+class SolarChargingEnableShort(MetronEVBaseEntity, SensorEntity):
     """Metron station status entity."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_solar_charging_enable_short"
-        self._attr_name = f"{hub._name} solar charging state"
+        self._attr_unique_id = f"{hub.name}_solar_charging_enable_short"
+        self._attr_name = f"{hub.name} solar charging state"
 
     @property
     def state(self) -> str:
@@ -367,16 +379,16 @@ class SolarChargingEnableShort(MetronEVBaseEntity):
         else:
             return "ON"
 
-class TotalChargingPower(MetronEVBaseEntity):
+class TotalChargingPower(MetronEVBaseEntity, SensorEntity):
     """Metron station status entity."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_total_charging_power"
-        self._attr_name = f"{hub._name} total charging power"
+        self._attr_unique_id = f"{hub.name}_total_charging_power"
+        self._attr_name = f"{hub.name} total charging power"
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_unit_of_measurement = UnitOfPower.WATT
+        self._attr_native_unit_of_measurement = UnitOfPower.WATT
         self._attr_device_class = SensorDeviceClass.POWER
 
     @property
@@ -385,16 +397,16 @@ class TotalChargingPower(MetronEVBaseEntity):
 
         return self._hub.total_charging_power
 
-class TotalHousePower(MetronEVBaseEntity):
+class TotalHousePower(MetronEVBaseEntity, SensorEntity):
     """Metron station status entity."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_total_house_power"
-        self._attr_name = f"{hub._name} total house power"
+        self._attr_unique_id = f"{hub.name}_total_house_power"
+        self._attr_name = f"{hub.name} total house power"
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_unit_of_measurement = UnitOfPower.WATT
+        self._attr_native_unit_of_measurement = UnitOfPower.WATT
         self._attr_device_class = SensorDeviceClass.POWER
 
     @property
@@ -403,16 +415,16 @@ class TotalHousePower(MetronEVBaseEntity):
 
         return self._hub.total_house_power
 
-class TotalSolarPower(MetronEVBaseEntity):
+class TotalSolarPower(MetronEVBaseEntity, SensorEntity):
     """Metron station status entity."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_total_solar_power"
-        self._attr_name = f"{hub._name} total solar power"
+        self._attr_unique_id = f"{hub.name}_total_solar_power"
+        self._attr_name = f"{hub.name} total solar power"
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_unit_of_measurement = UnitOfPower.WATT
+        self._attr_native_unit_of_measurement = UnitOfPower.WATT
         self._attr_device_class = SensorDeviceClass.POWER
 
     @property
@@ -421,16 +433,16 @@ class TotalSolarPower(MetronEVBaseEntity):
 
         return self._hub.total_solar_power
 
-class ThisChargeEnergy(MetronEVBaseEntity):
+class ThisChargeEnergy(MetronEVBaseEntity, SensorEntity):
     """Metron station status entity."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_this_charge_energy"
-        self._attr_name = f"{hub._name} this charge energy"
+        self._attr_unique_id = f"{hub.name}_this_charge_energy"
+        self._attr_name = f"{hub.name} this charge energy"
         self._attr_state_class = SensorStateClass.TOTAL
-        self._attr_unit_of_measurement = UnitOfEnergy.WATT_HOUR
+        self._attr_native_unit_of_measurement = UnitOfEnergy.WATT_HOUR
         self._attr_device_class = SensorDeviceClass.ENERGY
 
     @property
@@ -439,16 +451,16 @@ class ThisChargeEnergy(MetronEVBaseEntity):
 
         return self._hub.this_charge_energy
 
-class ChargingTime(MetronEVBaseEntity):
+class ChargingTime(MetronEVBaseEntity, SensorEntity):
     """Metron station status entity."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_charging_time"
-        self._attr_name = f"{hub._name} charging time"
+        self._attr_unique_id = f"{hub.name}_charging_time"
+        self._attr_name = f"{hub.name} charging time"
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_unit_of_measurement = UnitOfTime.MINUTES
+        self._attr_native_unit_of_measurement = UnitOfTime.MINUTES
         self._attr_device_class = SensorDeviceClass.DURATION
 
     @property
@@ -457,16 +469,16 @@ class ChargingTime(MetronEVBaseEntity):
         charging_time = (int(self._hub.hour_counter)*60)+int(self._hub.minute_counter)
         return charging_time
 
-class PreviousChargeEnergy(MetronEVBaseEntity):
+class PreviousChargeEnergy(MetronEVBaseEntity, SensorEntity):
     """Metron station status entity."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_previous_charge_energy"
-        self._attr_name = f"{hub._name} previous charge energy"
+        self._attr_unique_id = f"{hub.name}_previous_charge_energy"
+        self._attr_name = f"{hub.name} previous charge energy"
         self._attr_state_class = SensorStateClass.TOTAL
-        self._attr_unit_of_measurement = UnitOfEnergy.WATT_HOUR
+        self._attr_native_unit_of_measurement = UnitOfEnergy.WATT_HOUR
         self._attr_device_class = SensorDeviceClass.ENERGY
 
     @property
@@ -475,16 +487,16 @@ class PreviousChargeEnergy(MetronEVBaseEntity):
 
         return self._hub.previous_charge_energy
 
-class LifetimeEnergy(MetronEVBaseEntity):
+class LifetimeEnergy(MetronEVBaseEntity, SensorEntity):
     """Metron station status entity."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_lifetime_energy"
-        self._attr_name = f"{hub._name} lifetime energy"
+        self._attr_unique_id = f"{hub.name}_lifetime_energy"
+        self._attr_name = f"{hub.name} lifetime energy"
         self._attr_state_class = SensorStateClass.TOTAL_INCREASING
-        self._attr_unit_of_measurement = UnitOfEnergy.WATT_HOUR
+        self._attr_native_unit_of_measurement = UnitOfEnergy.WATT_HOUR
         self._attr_device_class = SensorDeviceClass.ENERGY
 
     @property
@@ -493,16 +505,16 @@ class LifetimeEnergy(MetronEVBaseEntity):
 
         return self._hub.lifetime_energy
 
-class SolarEnergy(MetronEVBaseEntity):
+class SolarEnergy(MetronEVBaseEntity, SensorEntity):
     """Metron solar energy lifetime counter."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_solar_energy"
-        self._attr_name = f"{hub._name} solar energy"
+        self._attr_unique_id = f"{hub.name}_solar_energy"
+        self._attr_name = f"{hub.name} solar energy"
         self._attr_state_class = SensorStateClass.TOTAL_INCREASING
-        self._attr_unit_of_measurement = UnitOfEnergy.WATT_HOUR
+        self._attr_native_unit_of_measurement = UnitOfEnergy.WATT_HOUR
         self._attr_device_class = SensorDeviceClass.ENERGY
 
     @property
@@ -511,16 +523,16 @@ class SolarEnergy(MetronEVBaseEntity):
 
         return self._hub.solar_energy
 
-class SolarSURPLUSPower(MetronEVBaseEntity):
+class SolarSURPLUSPower(MetronEVBaseEntity, SensorEntity):
     """Metron station status entity."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_solar_SURPLUS_power"
-        self._attr_name = f"{hub._name} solar SURPLUS power"
+        self._attr_unique_id = f"{hub.name}_solar_SURPLUS_power"
+        self._attr_name = f"{hub.name} solar SURPLUS power"
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_unit_of_measurement = UnitOfPower.WATT
+        self._attr_native_unit_of_measurement = UnitOfPower.WATT
         self._attr_device_class = SensorDeviceClass.POWER
 
     @property
@@ -529,14 +541,14 @@ class SolarSURPLUSPower(MetronEVBaseEntity):
 
         return self._hub.solar_SURPLUS_power
 
-class LocalNetworkIPString(MetronEVBaseEntity):
+class LocalNetworkIPString(MetronEVBaseEntity, SensorEntity):
     """Metron station status entity."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_local_network_IP_string"
-        self._attr_name = f"{hub._name} local network IP string"
+        self._attr_unique_id = f"{hub.name}_local_network_IP_string"
+        self._attr_name = f"{hub.name} local network IP string"
 
     @property
     def state(self) -> str:
@@ -544,16 +556,16 @@ class LocalNetworkIPString(MetronEVBaseEntity):
 
         return self._hub.local_network_IP_string
 
-class TimerDelay(MetronEVBaseEntity):
+class TimerDelay(MetronEVBaseEntity, SensorEntity):
     """Metron station status entity."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_ESP32_timer_delay"
-        self._attr_name = f"{hub._name} timer delay"
+        self._attr_unique_id = f"{hub.name}_ESP32_timer_delay"
+        self._attr_name = f"{hub.name} timer delay"
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_unit_of_measurement = UnitOfTime.MINUTES
+        self._attr_native_unit_of_measurement = UnitOfTime.MINUTES
         self._attr_device_class = SensorDeviceClass.DURATION
 
     @property
@@ -562,14 +574,14 @@ class TimerDelay(MetronEVBaseEntity):
 
         return int(self._hub.ESP32_timer_delay)
 
-class SignalPresent(MetronEVBaseEntity):
+class SignalPresent(MetronEVBaseEntity, SensorEntity):
     """Metron station status entity."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_HC12_Signal_Present"
-        self._attr_name = f"{hub._name} Telemetry Signal Present"
+        self._attr_unique_id = f"{hub.name}_HC12_Signal_Present"
+        self._attr_name = f"{hub.name} Telemetry Signal Present"
 
     @property
     def state(self) -> str:
@@ -579,33 +591,14 @@ class SignalPresent(MetronEVBaseEntity):
         else:
             return "No signal"
 
-class CarConnected(MetronEVBaseEntity):
-    """Metron station status entity."""
-
-    def __init__(self, hub) -> None:
-        """Initialize the sensor."""
-        super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_car_connected"
-        self._attr_name = f"{hub._name} car connected"
-        self._attr_is_on = False
-        self._attr_device_class = BinarySensorDeviceClass.PLUG
-
-    @property
-    def state(self) -> bool:
-        """Return the state of the sensor."""
-        if int(self._hub.metron_ev_status) in [2, 3, 4, 7]:
-            return True
-        else:
-            return False
-
-class MessageFormat(MetronEVBaseEntity):
+class MessageFormat(MetronEVBaseEntity, SensorEntity):
     """Reports the websocket message format detected from the charger firmware."""
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_message_format"
-        self._attr_name = f"{hub._name} message format"
+        self._attr_unique_id = f"{hub.name}_message_format"
+        self._attr_name = f"{hub.name} message format"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
@@ -614,21 +607,327 @@ class MessageFormat(MetronEVBaseEntity):
         return self._hub.message_format
 
 
-class CarCharging(MetronEVBaseEntity):
-    """Metron station status entity."""
+# --- Diagnostic sensors below: parsed from the protocol but not yet exposed.
+# Disabled by default (opt-in via entity settings) since usefulness/units of
+# several of these are not fully confirmed. See issue #65 discussion.
+
+class FirmwareVersion(MetronEVBaseEntity, SensorEntity):
+    """Metron Charge Control firmware version."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
 
     def __init__(self, hub) -> None:
         """Initialize the sensor."""
         super().__init__(hub)
-        self._attr_unique_id = f"{hub._name}_charging"
-        self._attr_name = f"{hub._name} charging"
-        self._attr_is_on = False
-        self._attr_device_class = BinarySensorDeviceClass.PLUG
+        self._attr_unique_id = f"{hub.name}_firmware_version"
+        self._attr_name = f"{hub.name} firmware version"
 
     @property
-    def state(self) -> bool:
-        """Return the state of the sensor."""
-        if int(self._hub.metron_ev_status) == 3 and int(self._hub._TCA0_cmp2) != 8000:
-            return True
-        else:
-            return False
+    def state(self) -> str | None:
+        """Return the firmware version, or None on legacy (pre-JSON) firmware."""
+        return self._hub.metron_charge_control_version
+
+
+class InternalTemperature(MetronEVBaseEntity, SensorEntity):
+    """Raw internal temperature sensor reading; unit/scale not confirmed from the protocol."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, hub) -> None:
+        """Initialize the sensor."""
+        super().__init__(hub)
+        self._attr_unique_id = f"{hub.name}_internal_temperature_raw"
+        self._attr_name = f"{hub.name} internal temperature (raw)"
+
+    @property
+    def state(self) -> int | None:
+        """Return the raw sensor value; unit unconfirmed from the protocol."""
+        return self._hub.temperature_sens_read
+
+
+class SolarPhases(MetronEVBaseEntity, SensorEntity):
+    """Configured number of solar phases."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, hub) -> None:
+        """Initialize the sensor."""
+        super().__init__(hub)
+        self._attr_unique_id = f"{hub.name}_solar_phases"
+        self._attr_name = f"{hub.name} solar phases"
+
+    @property
+    def state(self) -> int:
+        """Return the configured number of solar phases."""
+        return self._hub.solar_phases
+
+
+class HousePhases(MetronEVBaseEntity, SensorEntity):
+    """Configured number of house phases."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, hub) -> None:
+        """Initialize the sensor."""
+        super().__init__(hub)
+        self._attr_unique_id = f"{hub.name}_house_phases"
+        self._attr_name = f"{hub.name} house phases"
+
+    @property
+    def state(self) -> int:
+        """Return the configured number of house phases."""
+        return self._hub.house_phases
+
+
+class CarPhases(MetronEVBaseEntity, SensorEntity):
+    """Configured number of car phases."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, hub) -> None:
+        """Initialize the sensor."""
+        super().__init__(hub)
+        self._attr_unique_id = f"{hub.name}_car_phases"
+        self._attr_name = f"{hub.name} car phases"
+
+    @property
+    def state(self) -> int:
+        """Return the configured number of car phases."""
+        return self._hub.car_phases
+
+
+class SinceLastResetEnergy(MetronEVBaseEntity, SensorEntity):
+    """Energy counter since its last reset."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, hub) -> None:
+        """Initialize the sensor."""
+        super().__init__(hub)
+        self._attr_unique_id = f"{hub.name}_since_last_reset_energy"
+        self._attr_name = f"{hub.name} energy since last reset"
+        self._attr_state_class = SensorStateClass.TOTAL
+        self._attr_native_unit_of_measurement = UnitOfEnergy.WATT_HOUR
+        self._attr_device_class = SensorDeviceClass.ENERGY
+
+    @property
+    def state(self) -> int:
+        """Return the energy counter since its last reset."""
+        return self._hub.since_last_reset_energy
+
+
+class StationId(MetronEVBaseEntity, SensorEntity):
+    """Station identifier."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, hub) -> None:
+        """Initialize the sensor."""
+        super().__init__(hub)
+        self._attr_unique_id = f"{hub.name}_station_id"
+        self._attr_name = f"{hub.name} station ID"
+
+    @property
+    def state(self) -> int | None:
+        """Return the station identifier, or None on legacy (pre-JSON) firmware."""
+        return self._hub.id_station
+
+
+class NumberOfStations(MetronEVBaseEntity, SensorEntity):
+    """Number of stations reported by the charger."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, hub) -> None:
+        """Initialize the sensor."""
+        super().__init__(hub)
+        self._attr_unique_id = f"{hub.name}_number_of_stations"
+        self._attr_name = f"{hub.name} number of stations"
+
+    @property
+    def state(self) -> int:
+        """Return the number of stations reported by the charger."""
+        return self._hub.number_of_stations
+
+
+class ChargingCableMaxCurrent(MetronEVBaseEntity, SensorEntity):
+    """Charging cable's maximum current rating."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, hub) -> None:
+        """Initialize the sensor."""
+        super().__init__(hub)
+        self._attr_unique_id = f"{hub.name}_charging_cable_max_current"
+        self._attr_name = f"{hub.name} charging cable max current"
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+        self._attr_device_class = SensorDeviceClass.CURRENT
+
+    @property
+    def state(self) -> int:
+        """Return the charging cable's maximum current rating."""
+        return self._hub.charging_cable_max_current
+
+
+class Vreg1SetChargingCurrent(MetronEVBaseEntity, SensorEntity):
+    """Vreg1 set charging current."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, hub) -> None:
+        """Initialize the sensor."""
+        super().__init__(hub)
+        self._attr_unique_id = f"{hub.name}_vreg1_set_charging_current"
+        self._attr_name = f"{hub.name} Vreg1 set charging current"
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+        self._attr_device_class = SensorDeviceClass.CURRENT
+
+    @property
+    def state(self) -> int:
+        """Return the Vreg1 set charging current."""
+        return self._hub.vreg1_set_charging_current
+
+
+class Vreg2SetChargingCurrent(MetronEVBaseEntity, SensorEntity):
+    """Vreg2 set charging current."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, hub) -> None:
+        """Initialize the sensor."""
+        super().__init__(hub)
+        self._attr_unique_id = f"{hub.name}_vreg2_set_charging_current"
+        self._attr_name = f"{hub.name} Vreg2 set charging current"
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+        self._attr_device_class = SensorDeviceClass.CURRENT
+
+    @property
+    def state(self) -> int:
+        """Return the Vreg2 set charging current."""
+        return self._hub.vreg2_set_charging_current
+
+
+class StationMaxChargingCurrent(MetronEVBaseEntity, SensorEntity):
+    """Station's maximum charging current."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, hub) -> None:
+        """Initialize the sensor."""
+        super().__init__(hub)
+        self._attr_unique_id = f"{hub.name}_station_max_charging_current"
+        self._attr_name = f"{hub.name} station max charging current"
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+        self._attr_device_class = SensorDeviceClass.CURRENT
+
+    @property
+    def state(self) -> int:
+        """Return the station's maximum charging current."""
+        return self._hub.station_max_charging_current
+
+
+class FrontButtonState(MetronEVBaseEntity, SensorEntity):
+    """Front button raw value; exact semantics unconfirmed."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, hub) -> None:
+        """Initialize the sensor."""
+        super().__init__(hub)
+        self._attr_unique_id = f"{hub.name}_front_button"
+        self._attr_name = f"{hub.name} front button"
+
+    @property
+    def state(self) -> int | None:
+        """Return the raw front button value; exact semantics unconfirmed."""
+        return self._hub.front_button
+
+
+class DynamicChargingEnableFlag(MetronEVBaseEntity, SensorEntity):
+    """Dynamic charging enable flag; not a plain boolean, exact values unconfirmed."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, hub) -> None:
+        """Initialize the sensor."""
+        super().__init__(hub)
+        self._attr_unique_id = f"{hub.name}_dynamic_enable"
+        self._attr_name = f"{hub.name} dynamic charging enable flag"
+
+    @property
+    def state(self) -> int:
+        """Return the raw flag value; exact meaning of each value unconfirmed."""
+        return self._hub.dynamic_enable
+
+
+class GridPowerLimit(MetronEVBaseEntity, SensorEntity):
+    """Grid power limit setting; unit not confirmed from the protocol."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, hub) -> None:
+        """Initialize the sensor."""
+        super().__init__(hub)
+        self._attr_unique_id = f"{hub.name}_p_grid_limit"
+        self._attr_name = f"{hub.name} grid power limit"
+
+    @property
+    def state(self) -> int | None:
+        """Return the raw grid power limit value; unit unconfirmed from the protocol."""
+        return self._hub.p_grid_limit
+
+
+class GridSystem(MetronEVBaseEntity, SensorEntity):
+    """Grid system code; meaning unconfirmed from the protocol."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, hub) -> None:
+        """Initialize the sensor."""
+        super().__init__(hub)
+        self._attr_unique_id = f"{hub.name}_grid_system"
+        self._attr_name = f"{hub.name} grid system"
+
+    @property
+    def state(self) -> int | None:
+        """Return the raw grid system code; meaning unconfirmed from the protocol."""
+        return self._hub.grid_system
+
+
+class KwhLimitSlider(MetronEVBaseEntity, SensorEntity):
+    """kWh limit slider setting."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, hub) -> None:
+        """Initialize the sensor."""
+        super().__init__(hub)
+        self._attr_unique_id = f"{hub.name}_kwh_limit_slider"
+        self._attr_name = f"{hub.name} kWh limit slider"
+        self._attr_native_unit_of_measurement = "kWh"
+
+    @property
+    def state(self) -> int | None:
+        """Return the raw kWh limit slider value."""
+        return self._hub.kwh_limit_slider

--- a/custom_components/ev_metron_websockets/strings.json
+++ b/custom_components/ev_metron_websockets/strings.json
@@ -19,12 +19,17 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
+    }
+  },
+  "issues": {
+    "car_status_entities_moved": {
+      "title": "Car connected/charging entities moved to binary_sensor",
+      "description": "The car connected and charging entities moved from the sensor domain to binary_sensor (they were booleans incorrectly exposed as sensors). The old entities were removed; update any automations or dashboards that reference them:\n\n{changes}"
     }
   }
 }

--- a/custom_components/ev_metron_websockets/translations/en.json
+++ b/custom_components/ev_metron_websockets/translations/en.json
@@ -6,7 +6,6 @@
         },
         "error": {
             "cannot_connect": "Failed to connect",
-            "invalid_auth": "Invalid authentication",
             "unknown": "Unexpected error"
         },
         "step": {
@@ -26,6 +25,12 @@
                     "port": "Port"
                 }
             }
+        }
+    },
+    "issues": {
+        "car_status_entities_moved": {
+            "title": "Car connected/charging entities moved to binary_sensor",
+            "description": "The car connected and charging entities moved from the sensor domain to binary_sensor (they were booleans incorrectly exposed as sensors). The old entities were removed; update any automations or dashboards that reference them:\n\n{changes}"
         }
     }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,8 @@ for _mod in [
     "homeassistant.helpers",
     "homeassistant.helpers.entity",
     "homeassistant.helpers.entity_platform",
+    "homeassistant.helpers.entity_registry",
+    "homeassistant.helpers.issue_registry",
     "homeassistant.components",
     "homeassistant.components.sensor",
     "homeassistant.components.binary_sensor",
@@ -46,7 +48,28 @@ class SensorDeviceClass(str, enum.Enum):
     DURATION = "duration"
 
 
+class SensorEntity:
+    """Minimal stub mirroring the real SensorEntity's _attr_* fallback properties."""
+
+    _attr_state_class = None
+    _attr_native_unit_of_measurement = None
+    _attr_device_class = None
+
+    @property
+    def state_class(self):
+        return self._attr_state_class
+
+    @property
+    def native_unit_of_measurement(self):
+        return self._attr_native_unit_of_measurement
+
+    @property
+    def device_class(self):
+        return self._attr_device_class
+
+
 _sensor = sys.modules["homeassistant.components.sensor"]
+_sensor.SensorEntity = SensorEntity
 _sensor.SensorStateClass = SensorStateClass
 _sensor.SensorDeviceClass = SensorDeviceClass
 
@@ -54,9 +77,28 @@ _sensor.SensorDeviceClass = SensorDeviceClass
 
 class BinarySensorDeviceClass(str, enum.Enum):
     PLUG = "plug"
+    BATTERY_CHARGING = "battery_charging"
+    CONNECTIVITY = "connectivity"
 
 
-sys.modules["homeassistant.components.binary_sensor"].BinarySensorDeviceClass = BinarySensorDeviceClass
+class BinarySensorEntity:
+    """Minimal stub mirroring the real BinarySensorEntity's _attr_* fallback properties."""
+
+    _attr_is_on = None
+    _attr_device_class = None
+
+    @property
+    def is_on(self):
+        return self._attr_is_on
+
+    @property
+    def device_class(self):
+        return self._attr_device_class
+
+
+_binary_sensor = sys.modules["homeassistant.components.binary_sensor"]
+_binary_sensor.BinarySensorDeviceClass = BinarySensorDeviceClass
+_binary_sensor.BinarySensorEntity = BinarySensorEntity
 
 # --- homeassistant.const ---
 
@@ -66,6 +108,7 @@ class EntityCategory(str, enum.Enum):
 
 class Platform(str, enum.Enum):
     SENSOR = "sensor"
+    BINARY_SENSOR = "binary_sensor"
     BUTTON = "button"
     NUMBER = "number"
     SELECT = "select"
@@ -106,6 +149,51 @@ sys.modules["homeassistant.helpers.entity"].DeviceInfo = dict
 # --- homeassistant.helpers.entity_platform ---
 
 sys.modules["homeassistant.helpers.entity_platform"].AddEntitiesCallback = object
+
+# --- homeassistant.helpers.entity_registry ---
+
+
+class FakeEntityRegistry:
+    """In-memory stand-in for HA's entity registry, for tests to pre-populate/inspect."""
+
+    def __init__(self):
+        """Initialize with an empty registry."""
+        self._entity_ids: dict[tuple[str, str, str], str] = {}
+        self.removed: list[str] = []
+
+    def add(self, domain: str, platform: str, unique_id: str, entity_id: str) -> None:
+        self._entity_ids[(domain, platform, unique_id)] = entity_id
+
+    def async_get_entity_id(self, domain: str, platform: str, unique_id: str) -> str | None:
+        return self._entity_ids.get((domain, platform, unique_id))
+
+    def async_remove(self, entity_id: str) -> None:
+        self.removed.append(entity_id)
+        self._entity_ids = {k: v for k, v in self._entity_ids.items() if v != entity_id}
+
+
+def _entity_registry_async_get(hass):
+    return hass._fake_entity_registry
+
+
+_entity_registry = sys.modules["homeassistant.helpers.entity_registry"]
+_entity_registry.async_get = _entity_registry_async_get
+
+# --- homeassistant.helpers.issue_registry ---
+
+
+class IssueSeverity(str, enum.Enum):
+    WARNING = "warning"
+    ERROR = "error"
+
+
+def _issue_registry_async_create_issue(hass, domain, issue_id, **kwargs) -> None:
+    """No-op by default; tests monkeypatch this to capture calls."""
+
+
+_issue_registry = sys.modules["homeassistant.helpers.issue_registry"]
+_issue_registry.IssueSeverity = IssueSeverity
+_issue_registry.async_create_issue = _issue_registry_async_create_issue
 
 # --- websockets ---
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,36 @@
+"""Tests for the binary_sensor platform (moved out of sensor.py per issue #65)."""
+
+import types
+
+from homeassistant.components.binary_sensor import BinarySensorEntity, BinarySensorDeviceClass
+from custom_components.ev_metron_websockets.binary_sensor import CarConnected, CarCharging
+
+
+def _fake_hub(**attrs):
+    attrs.setdefault("name", "test")
+    return types.SimpleNamespace(**attrs)
+
+
+def test_car_connected_inherits_binary_sensor_entity():
+    assert issubclass(CarConnected, BinarySensorEntity)
+
+
+def test_car_connected_is_on_for_connected_statuses():
+    for status in (2, 3, 4, 7):
+        entity = CarConnected(_fake_hub(metron_ev_status=status))
+        assert entity.is_on is True
+    entity = CarConnected(_fake_hub(metron_ev_status=1))
+    assert entity.is_on is False
+    assert entity.device_class == BinarySensorDeviceClass.PLUG
+
+
+def test_car_charging_is_on_only_while_status_3_and_not_full():
+    entity = CarCharging(_fake_hub(metron_ev_status=3, TCA0_cmp2=100))
+    assert entity.is_on is True
+
+    entity = CarCharging(_fake_hub(metron_ev_status=3, TCA0_cmp2=8000))
+    assert entity.is_on is False
+
+    entity = CarCharging(_fake_hub(metron_ev_status=2, TCA0_cmp2=100))
+    assert entity.is_on is False
+    assert entity.device_class == BinarySensorDeviceClass.BATTERY_CHARGING

--- a/tests/test_diagnostic_sensors.py
+++ b/tests/test_diagnostic_sensors.py
@@ -1,0 +1,136 @@
+"""Tests for the diagnostic sensors added after inspecting a live charger payload (#65).
+
+These fields were previously parsed by metron.py but never read by hub.py or
+exposed as entities. All are disabled-by-default diagnostic entities since
+several units/scales aren't confirmed from the protocol alone.
+"""
+
+import types
+
+from homeassistant.const import EntityCategory
+from custom_components.ev_metron_websockets.metron import get_parsed_variables
+from custom_components.ev_metron_websockets.sensor import (
+    CarPhases,
+    ChargingCableMaxCurrent,
+    DynamicChargingEnableFlag,
+    FirmwareVersion,
+    FrontButtonState,
+    GridPowerLimit,
+    GridSystem,
+    HousePhases,
+    InternalTemperature,
+    KwhLimitSlider,
+    NumberOfStations,
+    SinceLastResetEnergy,
+    SolarPhases,
+    StationId,
+    StationMaxChargingCurrent,
+    Vreg1SetChargingCurrent,
+    Vreg2SetChargingCurrent,
+)
+from custom_components.ev_metron_websockets.binary_sensor import (
+    WifiToNetworkConnected,
+    WifiToNetworkEnabled,
+)
+
+# Captured live from a real charger (idle / "Ready to charge") while investigating #65.
+LIVE_PAYLOAD = (
+    '{"a":1,"b":0,"c":0,"d":0,"e":2,"f":1,"g":0,"h":13,"i":10,"j":20,"k":20,'
+    '"l":32,"m":32,"n":16,"o":10,"p":1,"q":1,"r":32,"s":1,"t":8000,"u":2,'
+    '"A":0,"B":0,"C":0,"D":0,"E":0,"F":9359129,"G":9359129,"H":32,"I":1,'
+    '"J":766,"K":28493302,"L":3,"M":3,"N":1,"O":8731,"P":30748422,"Q":7965,'
+    '"R":1,"S":"10.10.10.147","T":0,"U":2,"V":1,"W":10,"X":1,"Y":1,"Z":0,'
+    '"AA":0,"AB":"0.0.0.0","AC":320,"AD":"","AE":0,"AF":0,"AG":0,"AH":0,'
+    '"AI":1,"AJ":"1.09","AK":"X.XX","AL":93,"AM":0,"AN":3,"AO":0,"AP":0,'
+    '"AR":0,"AS":"","AT":0,"AU":0,"AV":0,"AW":0,"AX":"X.XX","AY":0,"AZ":0,'
+    '"BA":"","BB":0,"BC":0,"BD":10,"BE":1}'
+)
+
+_HUB_FIELDS = (
+    "Metron_Charge_Control_Version", "temperature_sens_read", "Solar_phases",
+    "House_phases", "Car_phases", "WiFi_to_network_enable", "WiFi_to_network_state",
+    "Since_last_reset_energy", "ID_station", "number_of_stations",
+    "Charging_cable_max_current", "Vreg1_set_charging_current",
+    "Vreg2_set_charging_current", "Station_max_charging_current", "Front_button",
+    "Dynamic_Enable", "P_grid_limit", "Grid_system", "kWh_limit_slider",
+)
+
+
+def _hub_from_live_payload():
+    """Build a fake hub the way MetronEVHub.update() would populate it from LIVE_PAYLOAD."""
+    parsed, fmt = get_parsed_variables(LIVE_PAYLOAD)
+    assert fmt == "json"
+    return types.SimpleNamespace(
+        name="Home Charger",
+        metron_charge_control_version=parsed["Metron_Charge_Control_Version"],
+        temperature_sens_read=parsed["temperature_sens_read"],
+        solar_phases=parsed["Solar_phases"],
+        house_phases=parsed["House_phases"],
+        car_phases=parsed["Car_phases"],
+        wifi_to_network_enable=parsed["WiFi_to_network_enable"],
+        wifi_to_network_state=parsed["WiFi_to_network_state"],
+        since_last_reset_energy=parsed["Since_last_reset_energy"],
+        id_station=parsed["ID_station"],
+        number_of_stations=parsed["number_of_stations"],
+        charging_cable_max_current=parsed["Charging_cable_max_current"],
+        vreg1_set_charging_current=parsed["Vreg1_set_charging_current"],
+        vreg2_set_charging_current=parsed["Vreg2_set_charging_current"],
+        station_max_charging_current=parsed["Station_max_charging_current"],
+        front_button=parsed["Front_button"],
+        dynamic_enable=parsed["Dynamic_Enable"],
+        p_grid_limit=parsed["P_grid_limit"],
+        grid_system=parsed["Grid_system"],
+        kwh_limit_slider=parsed["kWh_limit_slider"],
+    )
+
+
+def test_sensors_read_correct_fields_from_live_payload():
+    hub = _hub_from_live_payload()
+
+    assert FirmwareVersion(hub).state == "1.09"
+    assert InternalTemperature(hub).state == 93
+    assert SolarPhases(hub).state == 3
+    assert HousePhases(hub).state == 3
+    assert CarPhases(hub).state == 1
+    assert SinceLastResetEnergy(hub).state == 9359129
+    assert StationId(hub).state == 1
+    assert NumberOfStations(hub).state == 1
+    assert ChargingCableMaxCurrent(hub).state == 20
+    assert Vreg1SetChargingCurrent(hub).state == 32
+    assert Vreg2SetChargingCurrent(hub).state == 32
+    assert StationMaxChargingCurrent(hub).state == 16
+    assert FrontButtonState(hub).state == 1
+    assert DynamicChargingEnableFlag(hub).state == 2
+    assert GridPowerLimit(hub).state == 10
+    assert GridSystem(hub).state == 1
+    assert KwhLimitSlider(hub).state == 0
+
+
+def test_binary_sensors_read_correct_fields_from_live_payload():
+    hub = _hub_from_live_payload()
+    assert WifiToNetworkEnabled(hub).is_on is True
+    assert WifiToNetworkConnected(hub).is_on is True
+
+
+def test_all_new_sensors_are_disabled_diagnostic_by_default():
+    for cls in (
+        FirmwareVersion, InternalTemperature, SolarPhases, HousePhases, CarPhases,
+        SinceLastResetEnergy, StationId, NumberOfStations, ChargingCableMaxCurrent,
+        Vreg1SetChargingCurrent, Vreg2SetChargingCurrent, StationMaxChargingCurrent,
+        FrontButtonState, DynamicChargingEnableFlag, GridPowerLimit, GridSystem,
+        KwhLimitSlider, WifiToNetworkEnabled, WifiToNetworkConnected,
+    ):
+        assert cls._attr_entity_registry_enabled_default is False
+        assert cls._attr_entity_category == EntityCategory.DIAGNOSTIC
+
+
+def test_hub_update_keys_match_metron_parser_output():
+    """Regression guard against key typos between hub.py and metron.py.
+
+    Every new hub.py latest_message.get(key) must match a key metron.py's
+    JSON parser actually produces, or the hub attribute would silently stay
+    None forever — a real risk with ~19 fields added by hand.
+    """
+    parsed, _ = get_parsed_variables(LIVE_PAYLOAD)
+    for key in _HUB_FIELDS:
+        assert key in parsed

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,0 +1,79 @@
+"""Tests for MetronEVHub: public accessors, connection testing, update resilience."""
+
+import asyncio
+import types
+
+import websockets
+from websockets.protocol import State
+
+from custom_components.ev_metron_websockets.hub import MetronEVHub
+
+
+def _make_hub():
+    return MetronEVHub(types.SimpleNamespace(), "Home Charger", "192.168.1.50", 80)
+
+
+def test_public_accessors_expose_hub_identity():
+    hub = _make_hub()
+    assert hub.name == "Home Charger"
+    assert hub.host == "192.168.1.50"
+    assert hub.id == "192.168.1.50"
+
+
+class _FakeWebSocket:
+    def __init__(self, state):
+        self.state = state
+
+
+class _FakeConnectCtx:
+    """Stand-in for the object returned by websockets.connect()."""
+
+    def __init__(self, state=None, exc=None):
+        self._state = state
+        self._exc = exc
+
+    async def __aenter__(self):
+        if self._exc:
+            raise self._exc
+        return _FakeWebSocket(self._state)
+
+    async def __aexit__(self, *args):
+        return False
+
+
+def test_endpoint_returns_true_when_open(monkeypatch):
+    hub = _make_hub()
+    monkeypatch.setattr(websockets, "connect", lambda uri: _FakeConnectCtx(state=State.OPEN))
+    assert asyncio.run(hub.test_endpoint()) is True
+
+
+def test_endpoint_returns_false_on_connection_error(monkeypatch):
+    """Real connection failures (host down, refused, ...) must not raise out of test_endpoint."""
+    hub = _make_hub()
+    monkeypatch.setattr(websockets, "connect", lambda uri: _FakeConnectCtx(exc=ConnectionRefusedError()))
+    assert asyncio.run(hub.test_endpoint()) is False
+
+
+def test_endpoint_returns_false_on_websocket_exception(monkeypatch):
+    hub = _make_hub()
+    monkeypatch.setattr(websockets, "connect", lambda uri: _FakeConnectCtx(exc=websockets.WebSocketException()))
+    assert asyncio.run(hub.test_endpoint()) is False
+
+
+def test_publish_updates_isolates_callback_errors():
+    """One entity failing to compute state must not stop other entities updating."""
+    hub = _make_hub()
+    calls = []
+
+    def bad_callback():
+        raise RuntimeError("boom")
+
+    def good_callback():
+        calls.append("ok")
+
+    hub.register_callback(bad_callback)
+    hub.register_callback(good_callback)
+
+    asyncio.run(hub.publish_updates())  # must not raise
+
+    assert calls == ["ok"]

--- a/tests/test_init_migration.py
+++ b/tests/test_init_migration.py
@@ -1,0 +1,53 @@
+"""Tests for the sensor.* -> binary_sensor.* registry migration (issue #65)."""
+
+import types
+
+import homeassistant.helpers.issue_registry as ir
+from custom_components.ev_metron_websockets import _async_migrate_car_status_entities
+from tests.conftest import FakeEntityRegistry
+
+
+def _fake_hass():
+    hass = types.SimpleNamespace()
+    hass._fake_entity_registry = FakeEntityRegistry()
+    return hass
+
+
+def _fake_entry(entry_id="abc123"):
+    return types.SimpleNamespace(entry_id=entry_id)
+
+
+def _fake_hub(name="test"):
+    return types.SimpleNamespace(name=name)
+
+
+def test_removes_old_sensor_entities_and_raises_issue(monkeypatch):
+    hass = _fake_hass()
+    registry = hass._fake_entity_registry
+    registry.add("sensor", "ev_metron_websockets", "test_car_connected", "sensor.test_car_connected")
+    registry.add("sensor", "ev_metron_websockets", "test_charging", "sensor.test_charging")
+
+    created_issues = []
+    monkeypatch.setattr(ir, "async_create_issue", lambda hass, domain, issue_id, **kw: created_issues.append((domain, issue_id, kw)))
+
+    _async_migrate_car_status_entities(hass, _fake_entry(), _fake_hub())
+
+    assert sorted(registry.removed) == ["sensor.test_car_connected", "sensor.test_charging"]
+    assert len(created_issues) == 1
+    domain, issue_id, kwargs = created_issues[0]
+    assert domain == "ev_metron_websockets"
+    assert issue_id == "car_status_entities_moved_abc123"
+    assert "sensor.test_car_connected -> binary_sensor.test_car_connected" in kwargs["translation_placeholders"]["changes"]
+    assert "sensor.test_charging -> binary_sensor.test_charging" in kwargs["translation_placeholders"]["changes"]
+
+
+def test_no_op_when_nothing_to_migrate(monkeypatch):
+    hass = _fake_hass()
+
+    created_issues = []
+    monkeypatch.setattr(ir, "async_create_issue", lambda *a, **kw: created_issues.append((a, kw)))
+
+    _async_migrate_car_status_entities(hass, _fake_entry(), _fake_hub())
+
+    assert hass._fake_entity_registry.removed == []
+    assert created_issues == []

--- a/tests/test_metron.py
+++ b/tests/test_metron.py
@@ -75,11 +75,16 @@ class TestAssignVariables:
         assert result["Status"] == 3
 
     def test_short_message_no_exception(self):
-        """Older firmware sending fewer fields must not raise."""
+        """Older firmware sending fewer fields must not raise; missing fields default."""
         result = assign_variables([1, 5, 3])
         assert result["Status"] == 1
         assert result["L1_current_station"] == 5
-        assert "Lifetime_energy" not in result  # field absent, not present as None
+        # Missing fields default to 0/"" like assign_variables_json does, rather
+        # than being left out of the dict — callers doing int(hub.xxx) on a
+        # missing field would otherwise crash on int(None).
+        assert result["Lifetime_energy"] == 0
+        assert result["Local_network_IP_string"] == ""
+        assert len(result) == 45
 
     def test_long_message_no_exception(self):
         """Newer firmware with extra fields must not raise; extras are ignored."""
@@ -155,6 +160,18 @@ class TestAssignVariablesJson:
         assert result["Previous_charge_energy"] == 4200
         assert result["Solar_energy"] == 45000
         assert result["House_energy"] == 87000
+
+    def test_field_names_match_legacy_parser(self):
+        """The JSON and legacy parsers must use identical names for the same field.
+
+        These are our own internal labels (the firmware only ever sends
+        single/double-letter keys), so any mismatch here is our own bug.
+        """
+        json_result = assign_variables_json(FULL_JSON_OBJ)
+        legacy_result = assign_variables([0] * 45)
+        for shared_field in ("PWMRegister_ESP32_reply_Amps", "PWMRegister_ESP32_slider_Amps", "number_of_stations"):
+            assert shared_field in json_result
+            assert shared_field in legacy_result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sensor_entities.py
+++ b/tests/test_sensor_entities.py
@@ -1,0 +1,43 @@
+"""Regression tests for GitHub issue #65: sensor state_class/unit not exposed to HA.
+
+Sensor entities only inherited from MetronEVBaseEntity(Entity), never from
+SensorEntity, so _attr_state_class / _attr_native_unit_of_measurement were
+set but never surfaced through HA's state_class/native_unit_of_measurement
+properties.
+"""
+
+import types
+
+from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
+from custom_components.ev_metron_websockets.sensor import LifetimeEnergy, L1CurrentStation, MetronName
+
+
+def _fake_hub(**attrs):
+    attrs.setdefault("name", "test")
+    return types.SimpleNamespace(**attrs)
+
+
+def test_sensor_entities_inherit_sensor_entity():
+    assert issubclass(LifetimeEnergy, SensorEntity)
+    assert issubclass(L1CurrentStation, SensorEntity)
+
+
+def test_state_class_and_unit_exposed():
+    entity = LifetimeEnergy(_fake_hub(lifetime_energy=42))
+    assert entity.state_class == SensorStateClass.TOTAL_INCREASING
+    assert entity.native_unit_of_measurement == "Wh"
+    assert entity.device_class == SensorDeviceClass.ENERGY
+
+
+def test_measurement_sensor_exposes_current_unit():
+    entity = L1CurrentStation(_fake_hub(L1_current_station=6))
+    assert entity.state_class == SensorStateClass.MEASUREMENT
+    assert entity.native_unit_of_measurement == "A"
+    assert entity.device_class == SensorDeviceClass.CURRENT
+
+
+def test_sensor_without_state_class_defaults_to_none():
+    entity = MetronName(_fake_hub(name="Charger"))
+    assert entity.state_class is None
+    assert entity.native_unit_of_measurement is None
+    assert entity.state == "Charger"


### PR DESCRIPTION
## Summary

- Fixes #65: sensor entities never inherited `SensorEntity` (only `MetronEVBaseEntity(Entity)`), so `state_class`/`device_class`/unit were set but never surfaced to HA. Now they do, across all sensors.
- `CarConnected`/`CarCharging` moved to a proper `binary_sensor` platform (were booleans wrongly exposed as `SensorEntity` with a `BinarySensorDeviceClass`); old `sensor.*` entries are removed on upgrade with a Repairs issue pointing at the new entity_ids.
- Truncated legacy (non-JSON) messages no longer leave hub attributes as `None` — a real crash risk (`int(None)`) that could force a full websocket reconnect on a single malformed message. `hub.publish_updates()` also now isolates per-entity callback errors.
- `hub.test_endpoint()` now catches connection errors; collapsed the dead `InvalidAuth`/`CannotConnect` split in `config_flow.py` (this integration has no auth concept — leftover from the template it was built from).
- Removed private-attribute reach-through (`hub._name`, `hub._ESP32_timer_delay`, etc.) in favor of hub's own public properties.
- Normalized field-name casing between the legacy/JSON parsers (internal labels only, not firmware-defined).
- Added 19 previously-unexposed sensors found by inspecting a live charger payload — disabled-by-default diagnostic entities (firmware version, phase config, WiFi status, current limits, grid settings, etc.).
- Bumped manifest version to `0.6.0` — `0.5.0` was tagged/released without ever bumping `manifest.json`, so HACS never actually saw it as an update.

## Test plan

- [x] `ruff check .` clean
- [x] `pytest tests/` — 43/43 passing (grown from 24)
- [x] New/changed-behavior tests confirmed to fail against the pre-fix code and pass against the fix (state_class exposure, legacy message padding, hub connection/update resilience, registry migration)
- [x] New diagnostic sensors validated against a real payload captured live from a charger on the network